### PR TITLE
Run the existing tests with deno (syhol repo)

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,0 +1,22 @@
+name: Deno CI
+
+on:
+  push:
+    branches: main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: "1.37.0"
+
+      - name: Run Tests
+        run: cd ./library && deno task test

--- a/library/deno.json
+++ b/library/deno.json
@@ -1,0 +1,9 @@
+{
+  "lock": false,
+  "tasks": {
+    "test": "deno test --allow-read"
+  },
+  "imports": {
+    "vitest": "./src/testUtils/denoVitestPolyfill.ts"
+  }
+}

--- a/library/mod.test.ts
+++ b/library/mod.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from 'vitest';
+
+describe('Deno compatibility', () => {
+  test('should be able to import mod.ts', async () => {
+    const module = await import('./mod.ts');
+    expect(module).not.toBeUndefined();
+  })
+});

--- a/library/src/schemas/record/record.test.ts
+++ b/library/src/schemas/record/record.test.ts
@@ -151,6 +151,7 @@ describe('record', () => {
   test('should prevent prototype pollution', () => {
     const schema = record(string(), any());
     const input = JSON.parse('{"__proto__":{"polluted":"yes"}}');
+    expect(input.__proto__.polluted).toBe('yes');
     expect(({} as any).polluted).toBeUndefined();
     const output = parse(schema, input);
     expect(output.__proto__?.polluted).toBeUndefined();

--- a/library/src/schemas/record/record.test.ts
+++ b/library/src/schemas/record/record.test.ts
@@ -151,10 +151,9 @@ describe('record', () => {
   test('should prevent prototype pollution', () => {
     const schema = record(string(), any());
     const input = JSON.parse('{"__proto__":{"polluted":"yes"}}');
-    expect(input.__proto__.polluted).toBe('yes');
     expect(({} as any).polluted).toBeUndefined();
     const output = parse(schema, input);
-    expect(output.__proto__.polluted).toBeUndefined();
+    expect(output.__proto__?.polluted).toBeUndefined();
     expect(output.polluted).toBeUndefined();
   });
 });

--- a/library/src/schemas/record/recordAsync.test.ts
+++ b/library/src/schemas/record/recordAsync.test.ts
@@ -157,6 +157,7 @@ describe('recordAsync', () => {
   test('should prevent prototype pollution', async () => {
     const schema = recordAsync(string(), any());
     const input = JSON.parse('{"__proto__":{"polluted":"yes"}}');
+    expect(input.__proto__.polluted).toBe('yes');
     expect(({} as any).polluted).toBeUndefined();
     const output = await parseAsync(schema, input);
     expect(output.__proto__?.polluted).toBeUndefined();

--- a/library/src/schemas/record/recordAsync.test.ts
+++ b/library/src/schemas/record/recordAsync.test.ts
@@ -157,10 +157,9 @@ describe('recordAsync', () => {
   test('should prevent prototype pollution', async () => {
     const schema = recordAsync(string(), any());
     const input = JSON.parse('{"__proto__":{"polluted":"yes"}}');
-    expect(input.__proto__.polluted).toBe('yes');
     expect(({} as any).polluted).toBeUndefined();
     const output = await parseAsync(schema, input);
-    expect(output.__proto__.polluted).toBeUndefined();
+    expect(output.__proto__?.polluted).toBeUndefined();
     expect(output.polluted).toBeUndefined();
   });
 });

--- a/library/src/testUtils/denoVitestPolyfill.ts
+++ b/library/src/testUtils/denoVitestPolyfill.ts
@@ -1,0 +1,5 @@
+export * from "https://deno.land/std@0.202.0/testing/bdd.ts";
+export { it as test } from "https://deno.land/std@0.202.0/testing/bdd.ts";
+export { expectTypeOf } from 'npm:expect-type@0.16.0';
+import jestExpect from 'npm:expect@29.7.0';
+export const expect = jestExpect.default;


### PR DESCRIPTION
### See the upstream/main PR here: https://github.com/fabian-hiller/valibot/pull/179

This PR builds on the existing deno fix https://github.com/fabian-hiller/valibot/pull/178 and adds some new checks to make sure deno support does not break in future.

What does this PR do:

1. **Vitest polyfill**: Created a custom polyfill so Deno can run the vitest tests because vitest does not work in Deno today: https://github.com/denoland/deno/issues/19767.:
   - `library/src/testUtils/denoVitestPolyfill.ts`: 
     - Uses Deno stdlib `testing/bdd.ts` to provide `describe` and `it`. This uses `Deno.test` under the hood and doesn't support the same sort of API for skipping tests, however it does provide before* and after* functions.
     - Uses npm `expect` to provide `expect`. This is the jest expect package because I can't get vitest expect to work for the same reason the vitest runner won't work, however, it should be API compatible as that's a design goal of vitest.
   - `library/deno.json` -> `imports` key: redirect import of vitest to instead use the `denoVitestPolyfill.ts` when run through the Deno runtime.
   - I put this file under testUtils to make it clear it's a testing utility and because `src/comparison.ts` could be moved into this folder in a future PR.
2. **Fix tests run under deno**: Use optional chaining in `record.test.ts` and `recordAsync.test.ts` since unlike node, deno has no `__proto__` property on objects.
3. **New test for mod.ts**: A new test `library/mod.test.ts` that just checks that mod.ts can be imported.
4. **New GitHub workflow to run tests under Deno**: We could also just reuse the NodeJs workflow, happy to change this.

What do we get out of this PR:

1. The ability to run `deno task test` in the library directory to execute all existing tests with Deno
2. All tests are now running and passing under Deno
3. The tests will now fail if mod.ts fails to resolve dependencies
4. The ability to run the Deno workflow on PRs
